### PR TITLE
Allow preventScroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,15 @@ const Component = () => {
 
 ## API
 
-### `useConditionalFocus(shouldFocus: boolean, includeRoot: boolean)`
+### `useConditionalFocus(shouldFocus: boolean, includeRoot: boolean, preventScroll: boolean)`
 
 #### Arguments
 
-| Prop        | Type      | Default | Required? | Description                                                                        |
-| ----------- | --------- | ------- | --------- | ---------------------------------------------------------------------------------- |
-| shouldFocus | `boolean` | `false` | `Yes`     | Provide a `true` value here to focus the first focusable child in the element.     |
-| includeRoot | `boolean` | `false` | `No`      | When `true` this will try to focus on the root element in addition to its children |
+| Prop          | Type      | Default | Required? | Description                                                                                                          |
+| ------------- | --------- | ------- | --------- | -------------------------------------------------------------------------------------------------------------------- |
+| shouldFocus   | `boolean` | `false` | `Yes`     | Provide a `true` value here to focus the first focusable child in the element.                                       |
+| includeRoot   | `boolean` | `false` | `No`      | When `true` this will try to focus on the root element in addition to its children.                                  |
+| preventScroll | `boolean` | `false` | `No`      | When `true` this will prevent your browser from scrolling the document to bring the newly-focused element into view. |
 
 #### Returns `MutableRefObject<any>`
 

--- a/README.md
+++ b/README.md
@@ -51,13 +51,19 @@ const Component = () => {
 
 ## API
 
-### `useConditionalFocus(shouldFocus: boolean, includeRoot: boolean, preventScroll: boolean)`
+### `useConditionalFocus(shouldFocus: boolean, options: {includeRoot: boolean, preventScroll: boolean)}`
 
 #### Arguments
 
 | Prop          | Type      | Default | Required? | Description                                                                                                          |
 | ------------- | --------- | ------- | --------- | -------------------------------------------------------------------------------------------------------------------- |
 | shouldFocus   | `boolean` | `false` | `Yes`     | Provide a `true` value here to focus the first focusable child in the element.                                       |
+| options       | `object` \ `boolean` | `{includeRoot: false, preventScroll: false}` | `No`      | See `options`. Optionally pass a `boolean` instead (legacy fallback for `includeRoot`). When `true` this will try to focus on the root element in addition to its children.                                  |
+
+#### Options
+
+| Prop          | Type      | Default | Required? | Description                                                                                                          |
+| ------------- | --------- | ------- | --------- | -------------------------------------------------------------------------------------------------------------------- |
 | includeRoot   | `boolean` | `false` | `No`      | When `true` this will try to focus on the root element in addition to its children.                                  |
 | preventScroll | `boolean` | `false` | `No`      | When `true` this will prevent your browser from scrolling the document to bring the newly-focused element into view. |
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@accessible/use-conditional-focus",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "homepage": "https://github.com/accessible-ui/use-conditional-focus#readme",
   "repository": "github:accessible-ui/use-conditional-focus",
   "bugs": "https://github.com/accessible-ui/use-conditional-focus/issues",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,7 +5,8 @@ import useLayoutEffect from '@react-hook/passive-layout-effect'
 
 const useConditionalFocus = (
   shouldFocus = false,
-  includeRoot = false
+  includeRoot = false,
+  preventScroll = false
 ): MutableRefObject<any> => {
   const ref = useRef<any>(null)
 
@@ -15,7 +16,7 @@ const useConditionalFocus = (
       // Focuses on the first focusable element
       const doFocus = (): void => {
         const tabbableEls = tabbable(current, includeRoot)
-        if (tabbableEls.length > 0) tabbableEls[0].focus()
+        if (tabbableEls.length > 0) tabbableEls[0].focus({preventScroll})
       }
 
       raf(doFocus)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,12 +3,29 @@ import raf from 'raf'
 import tabbable from '@accessible/tabbable'
 import useLayoutEffect from '@react-hook/passive-layout-effect'
 
+export type ConditionalFocusOptions = {
+  includeRoot?: boolean
+  preventScroll?: boolean
+} | boolean
+
+const defaultOptions: ConditionalFocusOptions = {
+  includeRoot: false,
+  preventScroll: false
+}
+
 const useConditionalFocus = (
   shouldFocus = false,
-  includeRoot = false,
-  preventScroll = false
-): MutableRefObject<any> => {
+  options = defaultOptions as ConditionalFocusOptions): MutableRefObject<any> => {
   const ref = useRef<any>(null)
+
+  if (typeof options === 'boolean') {
+    options = {
+      ...defaultOptions,
+      includeRoot: options
+    }
+  }
+
+  const {includeRoot, preventScroll} = options
 
   useLayoutEffect(() => {
     const current = ref.current


### PR DESCRIPTION
Added option to prevent the document from scrolling to bring newly focused element into view.

https://developer.mozilla.org/en-US/docs/Web/API/HTMLOrForeignElement/focus